### PR TITLE
Explicitly set `targetArgument` for TermCheck

### DIFF
--- a/tools/releaseBuild/azureDevOps/templates/compliance.yml
+++ b/tools/releaseBuild/azureDevOps/templates/compliance.yml
@@ -78,8 +78,8 @@ jobs:
     displayName: 'Run PoliCheck'
     inputs:
       targetType: F
+      targetArgument: '$(Build.SourcesDirectory)'
       optionsFC: 0
-      optionsXS: 1
       optionsPE: '1|2|3|4'
       optionsHMENABLE: 0
       optionsRulesDBPath: '$(Build.SourcesDirectory)\tools\terms\PowerShell-Terms-Rules.mdb'


### PR DESCRIPTION
The `optionsXS` flag defaults to 1 (to enable recursion). What's missing is the target argument, our sources directory. (It's probably defaulting to the given value, but we can explicit about this.) We just need to not override `optionsXS` as we were previously doing with 0 to disable recursion.